### PR TITLE
small fix to achieve revoking mitigations

### DIFF
--- a/attackcti/attack_api.py
+++ b/attackcti/attack_api.py
@@ -251,7 +251,10 @@ class attack_client(object):
             if 'revoked' in obj.keys() and obj['revoked'] == True:
                 continue
             else:
-                non_revoked.append(obj)
+                if 'x_mitre_deprecated' in obj.keys() and obj['x_mitre_deprecated'] == True:
+                    continue
+                else:
+                    non_revoked.append(obj)
         return non_revoked
     
     def extract_revoked(self, stix_objects):


### PR DESCRIPTION
Hola Roberto/Jose Luis

your project helped me immensely recently, besides starring it I thought to commit a small improvement. I noticed remove revoked works for techniques but not for mitigations. This little PR allows that the remove_revoked function also supports removing revoked mitigations, which Mitre marks using a "x_mitre_deprecated" attribute which is different from how revoked technique objects are flagged. so with this pull request the function can be used for techniques as well as mitigations.

cheers and many thanks!  