### PR TITLE
Add support for campaings entity added in MITRE v12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ venv.bak/
 .idea/
 
 .DS_Store
+.history

--- a/attackcti/attack_api.py
+++ b/attackcti/attack_api.py
@@ -214,12 +214,13 @@ class attack_client(object):
             "created_by_ref": "created_by_ref",
             "created": "created",
             "modified": "modified",      
-            "title": "name",
+            "name": "name",
             "description": "campaign_description",
             "aliases": "campaign_aliases",
             "object_marking_refs": "object_marking_refs",
             "external_references": "external_references",
-
+            "x_mitre_first_seen_citation": "first_seen_citation",
+            "x_mitre_last_seen_citation": "last_seen_citation"
         }
 
         # ******** Helper Functions ********
@@ -694,7 +695,7 @@ class attack_client(object):
             List of STIX objects
         """
 
-        mobile_campaigns = self.TC_MOBILE_SOURCE.query(Filter("type", "=", "campaigns"))
+        mobile_campaigns = self.TC_MOBILE_SOURCE.query(Filter("type", "=", "campaign"))
 
         if skip_revoked_deprecated:
             mobile_campaigns = self.remove_revoked_deprecated(mobile_campaigns)
@@ -1352,7 +1353,7 @@ class attack_client(object):
             List of STIX objects
         
         """
-        valid_objects = {'attack-pattern','course-of-action','intrusion-set','malware','tool','x-mitre-data-source', 'x-mitre-data-component'}
+        valid_objects = {'attack-pattern','course-of-action','intrusion-set','malware','tool','x-mitre-data-source', 'x-mitre-data-component', 'campaign'}
         if object_type not in valid_objects:
             raise ValueError(f"ERROR: Valid object must be one of {valid_objects}")
         else:
@@ -1437,7 +1438,7 @@ class attack_client(object):
         
         """
         filter_objects = [
-            Filter('type', '=', 'campaigns'),
+            Filter('type', '=', 'campaign'),
             Filter('created', '>', timestamp)
         ]
         all_campaigns_list = self.COMPOSITE_DS.query(filter_objects)


### PR DESCRIPTION
I tried to follow code style and I've added following functionality:

```
from attack_api import attack_client
attack_client = attack_client()
ent_test = attack_client.get_enterprise_campaigns(stix_format=False)
mob_test = attack_client.get_mobile_campaigns(stix_format=False)
all_test = attack_client.get_campaigns(stix_format=False)
alias_test = attack_client.get_campaign_by_alias(campaign_alias="C0015", stix_format=False)
time_test = attack_client.get_campaigns_since_time(timestamp="2017-01-31T13:49:53.935Z", stix_format=False)
id_test = attack_client.get_object_by_attack_id("campaign", "C0001")
```