### PR TITLE
Fix a bug where all groups/campaigns are returned from case insensitive search of `get_group_by_alias`/`get_campaign_by_alias`

### DIFF
--- a/attackcti/attack_api.py
+++ b/attackcti/attack_api.py
@@ -1592,8 +1592,8 @@ class attack_client(object):
             all_groups_list = list()
             for group in all_groups:
                 if "aliases" in group.keys():
-                    for alias in group['aliases']:
-                        if alias.lower() in alias.lower():
+                    for group_alias in group['aliases']:
+                        if alias.lower() in group_alias.lower():
                             all_groups_list.append(group)
         else:
             filter_objects = [

--- a/attackcti/attack_api.py
+++ b/attackcti/attack_api.py
@@ -1558,8 +1558,8 @@ class attack_client(object):
             all_campaigns_list = list()
             for campaign in all_campaigns:
                 if "aliases" in campaign.keys():
-                    for alias in campaign['aliases']:
-                        if alias.lower() in alias.lower():
+                    for campaign_alias in campaign['aliases']:
+                        if alias.lower() in campaign_alias.lower():
                             all_campaigns_list.append(campaign)
         else:
             filter_objects = [


### PR DESCRIPTION
Bug is caused by the local variable `alias` clashing with the method parameter name (also `alias`) when performing a case insensitive search of `get_group_by_alias`/`get_campaign_by_alias`

In the 0.4.0 release I would get 1 result from the `get_group_by_alias` call but then I end up getting 400+ results in 0.4.1